### PR TITLE
[TheForest] FIX propose for issue #5

### DIFF
--- a/src/Libraries/Covalence/TheForestPlayer.cs
+++ b/src/Libraries/Covalence/TheForestPlayer.cs
@@ -35,7 +35,7 @@ namespace Oxide.Game.TheForest.Libraries.Covalence
             steamId = entity.source.RemoteEndPoint.SteamId.Id;
             cSteamId = new CSteamID(steamId);
             Id = steamId.ToString();
-            Name = entity.GetState<IPlayerState>().name ?? "Unnamed";
+            Name = entity.GetState<IPlayerState>().name?.Sanitize() ?? "Unnamed";
             this.entity = entity;
         }
 

--- a/src/Libraries/Covalence/TheForestPlayer.cs
+++ b/src/Libraries/Covalence/TheForestPlayer.cs
@@ -35,7 +35,7 @@ namespace Oxide.Game.TheForest.Libraries.Covalence
             steamId = entity.source.RemoteEndPoint.SteamId.Id;
             cSteamId = new CSteamID(steamId);
             Id = steamId.ToString();
-            Name = entity.GetState<IPlayerState>().name.Sanitize();
+            Name = entity.GetState<IPlayerState>().name ?? "Unnamed";
             this.entity = entity;
         }
 


### PR DESCRIPTION
## Issues related

#5 

## Tests

Tested do it log in and log out compulsively with changed applied and using in my own server

```
Starting dedicated server
Dedicated server info:
 IP:0.0.0.0, steamPort:27016, gamePort:27015, queryPort:27016
 players:100, admin password:'yes', password:'no', autosave interval:15
Game setup: Standard Multiplayer Server, New Normal game, slot Slot1
Skipping Steam initialization
DS configurations tests: Start tests
DS configurations tests: Host pass tests
Steam Manager Started.
Setting breakpad minidump AppID = 242760
GameServer init success. Port: 27015
Set a Logon
Loading Oxide Core v2.0.3773...
Loading extensions...
Latest compiler MD5: 5fbca0bf39b1c09ddf2fb3686b869242
Local compiler MD5: 5fbca0bf39b1c09ddf2fb3686b869242
Loaded extension CSharp v2.0.3776 by Oxide and Contributors
Loaded extension MySql v2.0.3752 by Oxide and Contributors
Loaded extension SQLite v2.0.3752 by Oxide and Contributors
Loaded extension TheForest v2.0.0 by Oxide and Contributors
Loaded extension Unity v2.0.3751 by Oxide and Contributors
Using Covalence provider for game 'The Forest'
Loading plugins...
Loaded plugin The Forest v2.0.0 by Oxide and Contributors
Loaded plugin Unity v2.0.3751 by Oxide and Contributors
Connected to Steam successfully
The Forest Server is VAC Secure!
Game server SteamID:REMOVED-BEFORE-COPY-TO-GITHUB
****** Game Activation Sequence ******
Dedicated Server Running
Address: [EndPoint 0.0.0.0:27015 | 27015]
Max Players: 100t Massive public SERVER+plugins                                                                                                                                                                                 81fps, 2m04s
Save Interval: 15 minutes                                                                                                                                                                                                  0b/s in, 0b/s out
Game autosave started
Connection:1
Steam auth - clientId 76561198016224106 status True
ClientApproved 76561198016224106
5612487636905149632/Netzulo joined
New player joined dedicated server. Total 1 player(s).
5612487636905149632/Netzulo quit
One player leave dedicated server. No players at the server.
Saving 32 trees that were cut down
Game saved
Connection:1
Steam auth - clientId 76561198016224106 status True
ClientApproved 76561198016224106
5612487636905157198/Netzulo joined
New player joined dedicated server. Total 1 player(s).
5612487636905157198/Netzulo quit
One player leave dedicated server. No players at the server.
Saving 32 trees that were cut down
Game saved
Connection:1
Steam auth - clientId 76561198016224106 status True
ClientApproved 76561198016224106
5612487636905157202/Netzulo joined
New player joined dedicated server. Total 1 player(s).
5612487636905157202/Netzulo quit
One player leave dedicated server. No players at the server.
Saving 32 trees that were cut down
Game saved
Connection:1
Steam auth - clientId 76561198016224106 status True
ClientApproved 76561198016224106
5612487636905162585/Unnamed joined
New player joined dedicated server. Total 1 player(s).
5612487636905162585/Netzulo quit
One player leave dedicated server. No players at the server.
Saving 32 trees that were cut down
Game saved
Connection:1
Steam auth - clientId 76561198368834641 status True
ClientApproved 76561198368834641
6344369623424629234/Unnamed joined
New player joined dedicated server. Total 1 player(s).
Connection:2
Steam auth - clientId 76561198041664669 status True
ClientApproved 76561198041664669
6344369623424619145/jjss10 joined
New player joined dedicated server. Total 2 player(s).
Connection:3
Steam auth - clientId 76561198311682056 status True
ClientApproved 76561198311682056
6344369623424629234/HijoDePutin quit
One player leave dedicated server. Total 1 player(s).
408962993469021789/Unnamed joined
New player joined dedicated server. Total 2 player(s).
6344369623424619145/jjss10 quit
One player leave dedicated server. Total 1 player(s).
408962993469021789/BullSoMuch quit
One player leave dedicated server. No players at the server.
Saving 32 trees that were cut down
Game saved
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          - .[ESP]netforest Massive public SERVER+plugins                                                                                                                                                                                62fps, 15m27s 0/100 players                                                                                                                                                                                                              0b/s in, 0b/s out Slot 1 [Normal]                                                                                                                                                                                         Oxide.TheForest 2.0.0 for 0.11.3.0.0
```